### PR TITLE
[FEATURE] user and group idstart integer

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -109,7 +109,8 @@ class ipa (
   $ldaputilspkg  = $::osfamily ? {
     Debian  => 'ldap-utils',
     default => 'openldap-clients',
-  }
+  },
+  $idstart       = false
 ) {
 
   @package { $ipa::svrpkg:
@@ -185,6 +186,10 @@ class ipa (
       validate_re($ipa::adminpw,'^.........*$','Parameter "adminpw" must be at least 8 characters long')
       validate_re($ipa::dspw,'^.........*$','Parameter "dspw" must be at least 8 characters long')
     }
+    if $ipa::master and $ipa::idstart {
+      validate_re($ipa::idstart,'^......*$', 'Parameter "idstart" must be an integer greater than 10000 ')
+      validate_re($ipa::idstart,'^\d+$', 'Parameter "idstart" must be an integer ')
+    }
 
     if ! $ipa::domain {
       fail('Required parameter "domain" missing')
@@ -242,7 +247,8 @@ class ipa (
       dirsrv_pin    => $ipa::dirsrv_pin,
       http_pin      => $ipa::http_pin,
       subject       => $ipa::subject,
-      selfsign      => $ipa::selfsign
+      selfsign      => $ipa::selfsign,
+      idstart       => $ipa::idstart
     }
 
     if ! $ipa::adminpw {

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -37,7 +37,8 @@ class ipa::master (
   $dirsrv_pin    = {},
   $http_pin      = {},
   $subject       = {},
-  $selfsign      = {}
+  $selfsign      = {},
+  $idstart       = {}
 ) {
 
   Ipa::Serverinstall[$::fqdn] ->  File['/etc/ipa/primary'] -> Ipa::Hostadd <<| |>> -> Ipa::Replicareplicationfirewall <<| tag == "ipa-replica-replication-firewall-${ipa::master::domain}" |>> -> Ipa::Replicaprepare <<| tag == "ipa-replica-prepare-${ipa::master::domain}" |>> -> Ipa::Createreplicas[$::fqdn]
@@ -113,6 +114,11 @@ class ipa::master (
     default => ''
   }
 
+  $idstartopt = $idstart ? {
+    false   => '',
+    default => "--idstart=$idstart"
+  }
+
   ipa::serverinstall { $::fqdn:
     realm         => $ipa::master::realm,
     domain        => $ipa::master::domain,
@@ -122,6 +128,7 @@ class ipa::master (
     forwarderopts => $ipa::master::forwarderopts,
     ntpopt        => $ipa::master::ntpopt,
     extcaopt      => $ipa::master::extcaopt,
+    idstartopt    => $ipa::master::idstartopt,
     require       => Package[$ipa::master::svrpkg]
   }
 

--- a/manifests/serverinstall.pp
+++ b/manifests/serverinstall.pp
@@ -10,11 +10,12 @@ define ipa::serverinstall (
   $dnsopt        = {},
   $forwarderopts = {},
   $ntpopt        = {},
-  $extcaopt      = {}
+  $extcaopt      = {},
+  $idstartopt    = {}
 ) {
 
   exec { "serverinstall-${host}":
-    command   => "/usr/sbin/ipa-server-install --hostname=${host} --realm=${realm} --domain=${domain} --admin-password=${adminpw} --ds-password=${dspw} $dnsopt $forwarderopts $ntpopt $extcaopt --unattended",
+    command   => "/usr/sbin/ipa-server-install --hostname=${host} --realm=${realm} --domain=${domain} --admin-password=${adminpw} --ds-password=${dspw} $dnsopt $forwarderopts $ntpopt $extcaopt $idstartopt --unattended",
     timeout   => '0',
     unless    => '/usr/sbin/ipactl status >/dev/null 2>&1',
     creates   => '/etc/ipa/default.conf',


### PR DESCRIPTION
for a definded rage of integer for user id and group id i added the feature, that at the time you provision the ipa server you can define the range.
Somethimes this feature is very helpfull, because if you do not setup the idstart integer, the ipa-server-install script make a random choice, and other static dependecies will fail.

This parameter:

idstart

is used by calling the class "ipa".

Refs: #7
Status: ready
